### PR TITLE
Add README for OctoAcme Project Management Docs (#2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,80 @@
+# OctoAcme Project Management Docs
+
+Welcome to OctoAcme's centralized project management documentation. This folder contains all the process guides, templates, and best practices that guide how we execute projects.
+
+## Project Management Processes Summary
+
+OctoAcme uses an **iterative, customer-oriented project management approach** that emphasizes:
+
+- **Clear Ownership**: Every project has a dedicated Project Manager (PM) and Product Lead
+- **Continuous Improvement**: We learn from each project and refine our processes
+- **Data-Informed Decision Making**: Success is measured against clear metrics
+- **Psychological Safety**: We encourage feedback and collaborative problem-solving
+
+### Project Lifecycle
+
+Our projects follow five key stages:
+
+1. **Initiation** — Validate the business need, align stakeholders, and define success criteria
+2. **Planning** — Break work into shippable increments with clear acceptance criteria and timelines
+3. **Execution & Tracking** — Deliver incrementally with daily standups, reviews, and quality gates
+4. **Release & Deployment** — Move features to production safely with validation and rollback plans
+5. **Retrospective & Continuous Improvement** — Capture learnings and convert them into actionable improvements
+
+### Core Roles
+
+- **Project Manager (PM)** — Coordinates delivery, schedules, risks, and communications
+- **Product Manager (PdM)** — Defines outcomes, prioritizes the backlog, and measures success
+- **Developers** — Implement features, collaborate on design, and ensure code quality
+- **QA/Testing** — Validate quality and ensure acceptance criteria are met
+- **Stakeholders** — Provide inputs, feedback, and approvals
+
+### Communication Cadence
+
+- Daily standups (15 min) — focus on progress, blockers, and dependencies
+- Weekly PM + PdM sync — alignment and priority discussion
+- Twice-weekly delivery team standups (or as agreed)
+- Monthly stakeholder updates
+- Ad-hoc escalations as needed
+
+## Process Documentation
+
+Browse the guides below to learn about each phase of our project management approach:
+
+### Core Processes
+
+- **[Project Management Overview](octoacme-project-management-overview.md)** — High-level introduction to OctoAcme principles, roles, and artifacts
+- **[Project Initiation Guide](octoacme-project-initiation.md)** — Define business need, align stakeholders, and create a lightweight plan
+- **[Project Planning](octoacme-project-planning.md)** — Turn an approved initiative into an actionable backlog and delivery plan
+- **[Execution & Tracking](octoacme-execution-and-tracking.md)** — Day-to-day execution, team rhythm, quality standards, and blocker escalation
+- **[Release & Deployment Guide](octoacme-release-and-deployment.md)** — Standardized approach to releasing features safely with validation and rollback plans
+- **[Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)** — Capture learnings and convert them into improvements
+
+### Supporting Resources
+
+- **[Risk Management & Communication](octoacme-risks-and-communication.md)** — Identify, assess, and communicate risks and dependencies
+- **[Roles & Personas](octoacme-roles-and-personas.md)** — Detailed descriptions of typical roles and responsibilities in OctoAcme projects
+
+## How to Use These Docs
+
+1. **New to OctoAcme?** Start with [Project Management Overview](octoacme-project-management-overview.md)
+2. **Starting a new project?** Follow the [Project Initiation Guide](octoacme-project-initiation.md)
+3. **Building a team?** Review the [Roles & Personas](octoacme-roles-and-personas.md)
+4. **Need a template or checklist?** Each process doc includes practical checklists and templates
+5. **Facing a challenge?** Check the relevant process doc or reach out to your Project Manager
+
+## Key Principles
+
+✓ **Customer-first** — Prioritize customer value and usability  
+✓ **Iterative delivery** — Deliver small, testable increments  
+✓ **Clear ownership** — Every project has named leads  
+✓ **Data-informed** — Measure impact and iterate based on evidence  
+✓ **Psychological safety** — Encourage feedback and learning  
+
+## Questions or Feedback?
+
+These docs are living artifacts. If you see gaps, have suggestions, or want to share lessons learned, please open an issue or reach out to your Project Manager.
+
+---
+
+*Last updated: 2026-02-09*


### PR DESCRIPTION
Closes #2 

Adds a comprehensive README for the OctoAcme Project Management Docs folder with links to all process documents and a summary of project management processes.